### PR TITLE
Fix docopt dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
     { name="nomike Postmann", email="nomike@nomike.com" },
 ]
 dependencies = [
-    "argparse",
+    "docopt",
     "numpy-stl",
 ]
 description = "Get dimensions of an STL file"

--- a/src/stldim/version.py
+++ b/src/stldim/version.py
@@ -7,6 +7,6 @@ __copyright__ = "Copyright 2024 nomike Postmann"
 __email__ = "nomike@nomike.com"
 __license__ = "MIT"
 __title__ = "stldim"
-__version__ = "0.2.1"
+__version__ = "0.2.2"
 
 __str__ = f'{__title__} v{__version__} by {__author__} <{__email__}>'


### PR DESCRIPTION
pyproject.toml still depended on argparse.